### PR TITLE
chore: bump version to 0.2.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]  # https://python-poetry.org/docs/pyproject/
 name = "utxorpc"
-version = "0.1.0"
+version = "0.2.0"
 description = "UTxO RPC SDK."
 authors = ["Felipe Gonzalez <felipe@txpipe.io>"]
 readme = "README.md"


### PR DESCRIPTION
## Summary
Version bump to 0.2.0

## Changes
- **utxorpc**: `0.1.0` → `0.2.0`

## Context
This release includes:
- Support for utxorpc-spec v0.18.1
- New clients: QueryClient, SubmitClient, SyncClient, WatchClient
- Cardano-specific implementations for all clients
- Transaction builder helper using PyCardano
- Comprehensive examples for all RPC operations

## Breaking Changes
- Python requirement updated to >=3.9.1
- Major refactoring of client structure

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)