### PR TITLE
feat: bump utxorpc-spec to 0.19.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ license = "Apache-2.0"
 
 [tool.poetry.dependencies]  # https://python-poetry.org/docs/dependency-specification/
 python = ">=3.9.1,<4.0"
-utxorpc-spec = "0.18.1"
+utxorpc-spec = "0.19.0"
 typing-extensions = "^4.15.0"
 protobuf = "^6.33.0"
 


### PR DESCRIPTION
Bumps `utxorpc-spec` 0.18.1 → 0.19.0 (UTxO RPC spec v0.19.0 line), as part of a coordinated cross-cutting spec bump across the u5c SDKs.

**Verification:** manifest bump only — NOT build-verified locally (poetry toolchain unavailable in the bump environment). Please confirm via CI.

Part of the u5c-factory `bump-sdk-spec` queue.