### PR TITLE
fix(deps): require protobuf >=7.34.1 for utxorpc-spec 0.19

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ license = "Apache-2.0"
 
 [tool.poetry.dependencies]  # https://python-poetry.org/docs/dependency-specification/
 python = ">=3.10,<4.0"
-utxorpc-spec = "0.19.1"
+utxorpc-spec = "0.19.2"
 typing-extensions = "^4.15.0"
 protobuf = "^7.34.1"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ license = "Apache-2.0"
 python = ">=3.9.1,<4.0"
 utxorpc-spec = "0.19.0"
 typing-extensions = "^4.15.0"
-protobuf = "^6.33.0"
+protobuf = "^7.34.1"
 
 
 [tool.poetry.group.dev.dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ license = "Apache-2.0"
 
 [tool.poetry.dependencies]  # https://python-poetry.org/docs/dependency-specification/
 python = ">=3.9.1,<4.0"
-utxorpc-spec = "0.19.0"
+utxorpc-spec = "0.19.1"
 typing-extensions = "^4.15.0"
 protobuf = "^7.34.1"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ repository = "https://github.com/utxorpc/python-sdk"
 license = "Apache-2.0"
 
 [tool.poetry.dependencies]  # https://python-poetry.org/docs/dependency-specification/
-python = ">=3.9.1,<4.0"
+python = ">=3.10,<4.0"
 utxorpc-spec = "0.19.1"
 typing-extensions = "^4.15.0"
 protobuf = "^7.34.1"

--- a/utxorpc/__init__.py
+++ b/utxorpc/__init__.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from .sync import CardanoBlock, CardanoPoint, CardanoSyncClient
 from .query import CardanoQueryClient
 from .submit import CardanoSubmitClient

--- a/utxorpc/generics/__init__.py
+++ b/utxorpc/generics/__init__.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import Optional, Protocol, TypeVar
 
 from utxorpc_spec.utxorpc.v1alpha.sync.sync_pb2 import (  # type: ignore

--- a/utxorpc/generics/clients/__init__.py
+++ b/utxorpc/generics/clients/__init__.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from contextlib import asynccontextmanager, contextmanager
 from functools import partial
 from typing import (

--- a/utxorpc/generics/clients/query.py
+++ b/utxorpc/generics/clients/query.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import AsyncGenerator, Any, Generic, List, Optional, Iterable, Union
 
 from utxorpc_spec.utxorpc.v1alpha.query.query_pb2 import (  # type: ignore

--- a/utxorpc/generics/clients/submit.py
+++ b/utxorpc/generics/clients/submit.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import AsyncGenerator, Any, Generic, Optional
 
 from utxorpc_spec.utxorpc.v1alpha.submit.submit_pb2 import (  # type: ignore

--- a/utxorpc/generics/clients/sync.py
+++ b/utxorpc/generics/clients/sync.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import asyncio
 from enum import Enum
 from typing import AsyncGenerator, Any, Generic, List, Optional, Iterable

--- a/utxorpc/generics/clients/watch.py
+++ b/utxorpc/generics/clients/watch.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import AsyncGenerator, Any, Generic, Optional
 from enum import Enum
 

--- a/utxorpc/query.py
+++ b/utxorpc/query.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from utxorpc.sync import CardanoBlock, CardanoPoint, CardanoChain
 from utxorpc.generics.clients.query import QueryClient
 

--- a/utxorpc/submit.py
+++ b/utxorpc/submit.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from utxorpc.sync import CardanoBlock, CardanoPoint, CardanoChain
 from utxorpc.generics.clients.submit import SubmitClient
 

--- a/utxorpc/sync.py
+++ b/utxorpc/sync.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import (
     Optional,
     Union,

--- a/utxorpc/watch.py
+++ b/utxorpc/watch.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from utxorpc.sync import CardanoBlock, CardanoPoint, CardanoChain
 from utxorpc.generics.clients.watch import WatchClient
 


### PR DESCRIPTION
## Problem

`utxorpc-spec` 0.19 ships protobuf **gencode 7.34.1**, but `pyproject.toml` pinned `protobuf = "^6.33.0"` (runtime <7.0). Protobuf requires the runtime version to be ≥ the linked gencode version, so `import utxorpc` failed:

```
google.protobuf.runtime_version.VersionError: Detected incompatible Protobuf Gencode/Runtime versions ... gencode 7.34.1 runtime 6.33.6
```

This completes the spec-0.19 bump, which raised `utxorpc-spec` but left `protobuf` behind.

## Fix

Bump the `protobuf` constraint to `^7.34.1`. CI relocks `poetry.lock` on a clean checkout.